### PR TITLE
feat: enhance design with media and animations

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -84,10 +84,40 @@ nav a.active {
 }
 
 .hero {
+  position: relative;
   text-align: center;
   padding: 3rem 1rem;
-  background-color: var(--primary-yellow);
-  color: var(--primary-black);
+  color: var(--primary-white);
+  overflow: hidden;
+}
+
+.hero::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(-45deg, var(--primary-yellow), var(--accent-blue), var(--primary-red), var(--primary-green));
+  background-size: 400% 400%;
+  animation: gradientShift 20s ease infinite;
+  opacity: 0.6;
+  z-index: 0;
+}
+
+.hero-video {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  z-index: -1;
+}
+
+.hero-content {
+  position: relative;
+  z-index: 1;
 }
 
 .hero h1 {
@@ -99,6 +129,21 @@ nav a.active {
   font-size: 1.1rem;
   max-width: 800px;
   margin: 0 auto;
+}
+
+.hero-gif {
+  width: 120px;
+  margin-top: 1rem;
+  border-radius: 8px;
+}
+
+.fade-in {
+  opacity: 0;
+  animation: fadeIn 1s ease forwards;
+}
+
+.fade-in.delay-1 {
+  animation-delay: 0.5s;
 }
 
 .section {
@@ -123,6 +168,18 @@ nav a.active {
   flex-direction: column;
   align-items: center;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.card:hover {
+  transform: translateY(-8px) scale(1.02);
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.2);
+}
+
+.card-image {
+  width: 100%;
+  border-radius: 6px;
+  margin-bottom: 0.5rem;
 }
 
 .card h2, .card h3 {
@@ -328,4 +385,27 @@ footer {
 /* When toggled, show answer */
 .faq-answer.open {
   display: block;
+}
+
+@keyframes gradientShift {
+  0% {
+    background-position: 0% 50%;
+  }
+  50% {
+    background-position: 100% 50%;
+  }
+  100% {
+    background-position: 0% 50%;
+  }
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }

--- a/index.html
+++ b/index.html
@@ -11,14 +11,21 @@
 
   <!-- Hero section -->
   <section class="hero">
-    <h1 data-i18n="hero_title">It's a match</h1>
-    <p data-i18n="hero_subtitle">You bring the delicious coffee. We bring the high‑end laptops. At OSiO, we believe great work starts with the right energy — and the right tools.</p>
+    <video class="hero-video" autoplay muted loop playsinline>
+      <source src="https://www.w3schools.com/howto/rain.mp4" type="video/mp4">
+    </video>
+    <div class="hero-content">
+      <h1 class="fade-in" data-i18n="hero_title">It's a match</h1>
+      <p class="fade-in delay-1" data-i18n="hero_subtitle">You bring the delicious coffee. We bring the high‑end laptops. At OSiO, we believe great work starts with the right energy — and the right tools.</p>
+      <img src="https://media.giphy.com/media/tJ4n0yWz1HEQbnuanS/giphy.gif" alt="Animated coffee cup" class="hero-gif">
+    </div>
   </section>
 
   <!-- Product cards -->
   <section class="section">
     <div class="card-container">
       <div class="card" id="card-baseline">
+        <img src="img/baseline1.png" alt="BaseLine laptop" class="card-image">
         <h2 data-i18n="baseline_title">BaseLine</h2>
         <p data-i18n="baseline_desc">Trusted helper for work & study</p>
         <p class="price" data-i18n="baseline_price">50,000 ETB</p>
@@ -26,6 +33,7 @@
         <button class="button-buy" onclick="buyProduct('BaseLine')" data-i18n="buy_button">Buy</button>
       </div>
       <div class="card" id="card-focusline">
+        <img src="img/focusline1.png" alt="FocusLine laptop" class="card-image">
         <h2 data-i18n="focus_title">FocusLine</h2>
         <p data-i18n="focus_desc">Stylish laptop for office & home</p>
         <p class="price" data-i18n="focus_price">40,333 ETB</p>
@@ -33,6 +41,7 @@
         <button class="button-buy" onclick="buyProduct('FocusLine')" data-i18n="buy_button">Buy</button>
       </div>
       <div class="card" id="card-cyberline">
+        <img src="img/cyberline1.png" alt="CyberLine laptop" class="card-image">
         <h2 data-i18n="cyber_title">CyberLine</h2>
         <p data-i18n="cyber_desc">Powerful device for games & editing</p>
         <p class="price" data-i18n="cyber_price">202,000 ETB</p>


### PR DESCRIPTION
## Summary
- Add animated hero section with video background, gradient overlay, fade-in text and GIF accent
- Show product photos and add hover animations on cards
- Introduce CSS keyframes for gradient and fade-in effects

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aa42977b808329b9b735cb3f5d55bd