### PR TITLE
Align laptop cards in single row

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -153,17 +153,18 @@ nav a.active {
 }
 
 .card-container {
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
   gap: 1.5rem;
-  justify-content: center;
+  justify-items: center;
 }
 
 .card {
   background-color: var(--primary-grey);
   border-radius: 8px;
   padding: 1rem;
-  width: 280px;
+  width: 100%;
+  max-width: 280px;
   display: flex;
   flex-direction: column;
   align-items: center;


### PR DESCRIPTION
## Summary
- Use CSS grid to place three laptop cards in a single row
- Ensure cards expand to fill their grid columns while keeping max width

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aaa2a3d18483298f0c1f0a48e57bae