### PR TITLE
Add hover flip specs to laptop cards

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -170,11 +170,40 @@ nav a.active {
   align-items: center;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   transition: transform 0.3s ease, box-shadow 0.3s ease;
+  perspective: 1000px;
 }
 
 .card:hover {
   transform: translateY(-8px) scale(1.02);
   box-shadow: 0 8px 20px rgba(0, 0, 0, 0.2);
+}
+
+.card-inner {
+  position: relative;
+  width: 100%;
+  height: 360px;
+  transform-style: preserve-3d;
+  transition: transform 0.6s;
+}
+
+.card:hover .card-inner {
+  transform: rotateY(180deg);
+}
+
+.card-front,
+.card-back {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  backface-visibility: hidden;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 0.5rem;
 }
 
 .card-image {
@@ -183,7 +212,7 @@ nav a.active {
   margin-bottom: 0.5rem;
 }
 
-.card h2, .card h3 {
+.card h2 {
   margin-top: 0;
   margin-bottom: 0.5rem;
 }
@@ -198,6 +227,18 @@ nav a.active {
   margin: 0.5rem 0;
 }
 
+.card-back {
+  transform: rotateY(180deg);
+  overflow-y: auto;
+  align-items: flex-start;
+  justify-content: flex-start;
+}
+
+.specs {
+  padding-left: 1rem;
+  text-align: left;
+}
+
 .card button {
   margin: 0.5rem;
   padding: 0.5rem 1rem;
@@ -207,51 +248,9 @@ nav a.active {
   font-size: 0.9rem;
 }
 
-.button-spec {
-  background-color: var(--primary-black);
-  color: var(--primary-white);
-}
-
 .button-buy {
   background-color: var(--primary-green);
   color: var(--primary-white);
-}
-
-.modal {
-  display: none;
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background: rgba(0, 0, 0, 0.5);
-  align-items: center;
-  justify-content: center;
-  padding: 1rem;
-}
-
-.modal-content {
-  background: var(--primary-white);
-  max-width: 600px;
-  width: 100%;
-  padding: 1.5rem;
-  border-radius: 8px;
-  max-height: 90vh;
-  overflow-y: auto;
-  position: relative;
-}
-
-.modal-content h3 {
-  margin-top: 0;
-}
-
-.modal-close {
-  position: absolute;
-  top: 0.5rem;
-  right: 0.5rem;
-  cursor: pointer;
-  font-size: 1.4rem;
-  color: var(--primary-red);
 }
 
 footer {

--- a/index.html
+++ b/index.html
@@ -25,80 +25,75 @@
   <section class="section">
     <div class="card-container">
       <div class="card" id="card-baseline">
-        <img src="img/baseline1.png" alt="BaseLine laptop" class="card-image">
-        <h2 data-i18n="baseline_title">BaseLine</h2>
-        <p data-i18n="baseline_desc">Trusted helper for work & study</p>
-        <p class="price" data-i18n="baseline_price">50,000 ETB</p>
-        <button class="button-spec" onclick="showModal('baseline')" data-i18n="spec_button">Specs</button>
+        <div class="card-inner">
+          <div class="card-front">
+            <img src="img/baseline1.png" alt="BaseLine laptop" class="card-image">
+            <h2 data-i18n="baseline_title">BaseLine</h2>
+            <p data-i18n="baseline_desc">Trusted helper for work & study</p>
+            <p class="price" data-i18n="baseline_price">50,000 ETB</p>
+          </div>
+          <div class="card-back">
+            <ul class="specs">
+              <li>Display: 15.6" FHD (1920×1080) IPS</li>
+              <li>Processor: Intel N100</li>
+              <li>Memory: 8 GB DDR4</li>
+              <li>Storage: 256 GB SSD</li>
+              <li>Graphics: Integrated Intel UHD</li>
+              <li>Battery: 5000 mAh</li>
+              <li>Ports: RJ45, HDMI, USB 2.0 ×1, USB 3.0 ×2, USB-C</li>
+              <li>Special: Webcam with privacy shutter; upgrade without voiding warranty</li>
+            </ul>
+          </div>
+        </div>
         <button class="button-buy" onclick="buyProduct('BaseLine')" data-i18n="buy_button">Buy</button>
       </div>
       <div class="card" id="card-focusline">
-        <img src="img/focusline1.png" alt="FocusLine laptop" class="card-image">
-        <h2 data-i18n="focus_title">FocusLine</h2>
-        <p data-i18n="focus_desc">Stylish laptop for office & home</p>
-        <p class="price" data-i18n="focus_price">40,333 ETB</p>
-        <button class="button-spec" onclick="showModal('focus')" data-i18n="spec_button">Specs</button>
+        <div class="card-inner">
+          <div class="card-front">
+            <img src="img/focusline1.png" alt="FocusLine laptop" class="card-image">
+            <h2 data-i18n="focus_title">FocusLine</h2>
+            <p data-i18n="focus_desc">Stylish laptop for office & home</p>
+            <p class="price" data-i18n="focus_price">40,333 ETB</p>
+          </div>
+          <div class="card-back">
+            <ul class="specs">
+              <li>Display: 16.1" FHD (1920×1080) IPS</li>
+              <li>Processor: Intel Core i3‑1115G4, 2 cores (up to 4.1 GHz)</li>
+              <li>Memory: 8 GB DDR4</li>
+              <li>Storage: 512 GB SSD</li>
+              <li>Graphics: Intel UHD</li>
+              <li>Operating system: No OS preinstalled</li>
+              <li>Weight: 1.77 kg</li>
+              <li>Special: Upgrade components without voiding warranty</li>
+            </ul>
+          </div>
+        </div>
         <button class="button-buy" onclick="buyProduct('FocusLine')" data-i18n="buy_button">Buy</button>
       </div>
       <div class="card" id="card-cyberline">
-        <img src="img/cyberline1.png" alt="CyberLine laptop" class="card-image">
-        <h2 data-i18n="cyber_title">CyberLine</h2>
-        <p data-i18n="cyber_desc">Powerful device for games & editing</p>
-        <p class="price" data-i18n="cyber_price">202,000 ETB</p>
-        <button class="button-spec" onclick="showModal('cyber')" data-i18n="spec_button">Specs</button>
+        <div class="card-inner">
+          <div class="card-front">
+            <img src="img/cyberline1.png" alt="CyberLine laptop" class="card-image">
+            <h2 data-i18n="cyber_title">CyberLine</h2>
+            <p data-i18n="cyber_desc">Powerful device for games & editing</p>
+            <p class="price" data-i18n="cyber_price">202,000 ETB</p>
+          </div>
+          <div class="card-back">
+            <ul class="specs">
+              <li>Display: 17.3" FHD (1920×1080) IPS</li>
+              <li>Processor: Intel Core i7 (gaming‑class)</li>
+              <li>Memory: 16 GB DDR4</li>
+              <li>Storage: 1 TB SSD</li>
+              <li>Graphics: Dedicated NVIDIA GPU</li>
+              <li>Operating system: No OS preinstalled</li>
+              <li>Special: Designed for gaming and creative work</li>
+            </ul>
+          </div>
+        </div>
         <button class="button-buy" onclick="buyProduct('CyberLine')" data-i18n="buy_button">Buy</button>
       </div>
     </div>
   </section>
-
-  <!-- Modal windows for specifications -->
-  <div class="modal" id="modal-baseline">
-    <div class="modal-content">
-      <span class="modal-close" onclick="closeModal('baseline')">×</span>
-      <h3>BaseLine</h3>
-      <ul>
-        <li>Display: 15.6" FHD (1920×1080) IPS</li>
-        <li>Processor: Intel N100</li>
-        <li>Memory: 8 GB DDR4</li>
-        <li>Storage: 256 GB SSD</li>
-        <li>Graphics: Integrated Intel UHD</li>
-        <li>Battery: 5000 mAh</li>
-        <li>Ports: RJ45, HDMI, USB 2.0 ×1, USB 3.0 ×2, USB-C</li>
-        <li>Special: Webcam with privacy shutter; upgrade without voiding warranty</li>
-      </ul>
-    </div>
-  </div>
-  <div class="modal" id="modal-focus">
-    <div class="modal-content">
-      <span class="modal-close" onclick="closeModal('focus')">×</span>
-      <h3>FocusLine</h3>
-      <ul>
-        <li>Display: 16.1" FHD (1920×1080) IPS</li>
-        <li>Processor: Intel Core i3‑1115G4, 2 cores (up to 4.1 GHz)</li>
-        <li>Memory: 8 GB DDR4</li>
-        <li>Storage: 512 GB SSD</li>
-        <li>Graphics: Intel UHD</li>
-        <li>Operating system: No OS preinstalled</li>
-        <li>Weight: 1.77 kg</li>
-        <li>Special: Upgrade components without voiding warranty</li>
-      </ul>
-    </div>
-  </div>
-  <div class="modal" id="modal-cyber">
-    <div class="modal-content">
-      <span class="modal-close" onclick="closeModal('cyber')">×</span>
-      <h3>CyberLine</h3>
-      <ul>
-        <li>Display: 17.3" FHD (1920×1080) IPS</li>
-        <li>Processor: Intel Core i7 (gaming‑class)</li>
-        <li>Memory: 16 GB DDR4</li>
-        <li>Storage: 1 TB SSD</li>
-        <li>Graphics: Dedicated NVIDIA GPU</li>
-        <li>Operating system: No OS preinstalled</li>
-        <li>Special: Designed for gaming and creative work</li>
-      </ul>
-    </div>
-  </div>
 
   <div id="footer-placeholder"></div>
 

--- a/js/main.js
+++ b/js/main.js
@@ -19,7 +19,6 @@ const translations = {
     cyber_title: "CyberLine",
     cyber_desc: "Мощный ноутбук для игр и монтажа",
     cyber_price: "202 000 ETB",
-    spec_button: "Характеристики",
     buy_button: "Купить",
     buy_intro: "Вы можете приобрести наши ноутбуки прямо на сайте через Chapa или у партнеров. Все цены указаны в ETB и включают курьерскую доставку или самовывоз в Аддис‑Абебе.",
     partners_title: "Партнеры и альтернативные способы покупки",
@@ -94,7 +93,6 @@ const translations = {
     cyber_title: "CyberLine",
     cyber_desc: "Powerful device for games & editing",
     cyber_price: "202,000 ETB",
-    spec_button: "Specs",
     buy_button: "Buy",
     buy_intro: "You can purchase our laptops directly through our website using Chapa, or via our partners. All prices are in ETB and include courier delivery or self‑pickup in Addis Ababa.",
     partners_title: "Partners & Alternative Purchasing",
@@ -169,7 +167,6 @@ const translations = {
     cyber_title: "CyberLine",
     cyber_desc: "ለጨዋታዎች እና ለስራዎች ብልህ መሳሪያ",
     cyber_price: "202,000 ETB",
-    spec_button: "ዝርዝሮች",
     buy_button: "መግዛት",
     buy_intro: "ላፖቶቻችንን በ Chapa በመጠቀም በእኛ ድር ገጽ ቀጥታ ወይም በጓደኞቻችን መግዛት ይችላሉ። ሁሉም ዋጋዎች በ ETB ይሰጣሉ፣ እና በአዲስ አበባ በኩርያ መድረስ ወይም በተጠቃሚው ራስ መውሰድ ያካትታሉ።",
     partners_title: "አጋር ሾለት እና የተለያዩ የግዢ አማራጮች",
@@ -403,21 +400,6 @@ document.addEventListener('partialsLoaded', () => {
     }
   });
 });
-
-// Modal functions
-function showModal(id) {
-  const modal = document.getElementById('modal-' + id);
-  if (modal) {
-    modal.style.display = 'flex';
-  }
-}
-
-function closeModal(id) {
-  const modal = document.getElementById('modal-' + id);
-  if (modal) {
-    modal.style.display = 'none';
-  }
-}
 
 // Payment integration using Chapa test keys via API route
 async function buyProduct(product) {


### PR DESCRIPTION
## Summary
- show laptop specs on card back with hover flip effect
- keep buy buttons visible below each card
- remove unused spec modal code

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68aaa3f26df483299b83bd65f5b3fa79