### PR TITLE
Fix Delivery & Pickup card layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -119,8 +119,9 @@
       <div class="buy-card">
         <img src="img/icons/bitcoin.svg" alt="Bitcoin" class="buy-icon">
         <h3><a href="https://t.me/zhiganovsasha" target="_blank">@zhiganovsasha</a></h3>
-        <p data-i18n="crypto_contact">Pay with cryptocurrency</p      </div>
-  /
+        <p data-i18n="crypto_contact">Pay with cryptocurrency</p>
+      </div>
+    </div>
     <div class="buy-info">
       <div class="shipping-box">
         <h3 data-i18n="shipping_title">Delivery & Pickup</h3>


### PR DESCRIPTION
## Summary
- Fix markup so the Delivery & Pickup card sits beneath the three partner cards instead of inside the cryptocurrency card.

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ac003f88b083299694cb4e010968d0