### PR TITLE
Add checkout pop-up links

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -524,3 +524,43 @@ footer {
   color: var(--primary-black);
   font-weight: bold;
 }
+
+/* Checkout popup styles */
+.checkout-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10000;
+}
+
+.checkout-popup {
+  position: relative;
+  width: 90%;
+  max-width: 600px;
+  height: 90%;
+  background: var(--primary-white);
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
+}
+
+.checkout-popup iframe {
+  width: 100%;
+  height: 100%;
+  border: none;
+}
+
+.checkout-close {
+  position: absolute;
+  top: 0.25rem;
+  right: 0.5rem;
+  font-size: 2rem;
+  background: none;
+  border: none;
+  color: var(--primary-black);
+  cursor: pointer;
+}

--- a/js/main.js
+++ b/js/main.js
@@ -407,29 +407,38 @@ document.addEventListener('partialsLoaded', () => {
   });
 });
 
-// Payment integration using Chapa test keys via API route
-async function buyProduct(product) {
-  const email = prompt('Enter your email:');
-  const firstName = prompt('First name:');
-  const lastName = prompt('Last name:');
-  if (!email || !firstName) return;
-  const amounts = { 'BaseLine': 50000, 'FocusLine': 40333, 'CyberLine': 202000 };
-  const amount = amounts[product] || 0;
-  try {
-    const response = await fetch('/api/checkout', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ amount: amount.toString(), email, first_name: firstName, last_name: lastName })
-    });
-    const data = await response.json();
-    if (data && data.data && data.data.checkout_url) {
-      window.location.href = data.data.checkout_url;
-    } else {
-      alert('Payment initialization failed');
+// Open Chapa checkout links inside a darkened popup overlay
+const checkoutLinks = {
+  BaseLine: "http://checkout.chapa.co/checkout/web/payment/PL-S719TpsZ4WPy",
+  FocusLine: "http://checkout.chapa.co/checkout/web/payment/PL-52hYW0bOFVCu",
+  CyberLine: "http://checkout.chapa.co/checkout/web/payment/PL-bEbrRRqTcFng"
+};
+
+function buyProduct(product) {
+  const url = checkoutLinks[product];
+  if (!url) return;
+
+  const overlay = document.createElement('div');
+  overlay.className = 'checkout-overlay';
+  overlay.innerHTML = `
+    <div class="checkout-popup">
+      <button class="checkout-close">&times;</button>
+      <iframe src="${url}" frameborder="0"></iframe>
+    </div>`;
+
+  document.body.appendChild(overlay);
+  document.body.style.overflow = 'hidden';
+
+  const close = () => {
+    overlay.remove();
+    document.body.style.overflow = '';
+  };
+
+  overlay.addEventListener('click', e => {
+    if (e.target === overlay || e.target.classList.contains('checkout-close')) {
+      close();
     }
-  } catch (err) {
-    alert('Error: ' + err.message);
-  }
+  });
 }
 
 // FAQ accordion toggling

--- a/js/main.js
+++ b/js/main.js
@@ -409,9 +409,9 @@ document.addEventListener('partialsLoaded', () => {
 
 // Open Chapa checkout links inside a darkened popup overlay
 const checkoutLinks = {
-  BaseLine: "http://checkout.chapa.co/checkout/web/payment/PL-S719TpsZ4WPy",
-  FocusLine: "http://checkout.chapa.co/checkout/web/payment/PL-52hYW0bOFVCu",
-  CyberLine: "http://checkout.chapa.co/checkout/web/payment/PL-bEbrRRqTcFng"
+  BaseLine: "https://checkout.chapa.co/checkout/web/payment/PL-S719TpsZ4WPy",
+  FocusLine: "https://checkout.chapa.co/checkout/web/payment/PL-52hYW0bOFVCu",
+  CyberLine: "https://checkout.chapa.co/checkout/web/payment/PL-bEbrRRqTcFng"
 };
 
 function buyProduct(product) {


### PR DESCRIPTION
## Summary
- link BaseLine, FocusLine, and CyberLine buttons to specific Chapa checkout URLs
- show checkout links in an on-page popup that darkens the rest of the site

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ac012814048329bfddaa845d520b73