### PR TITLE
Add popup checkout links for product purchases

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -524,3 +524,42 @@ footer {
   color: var(--primary-black);
   font-weight: bold;
 }
+
+/* Payment popup overlay */
+#payment-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.8);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  z-index: 10000;
+}
+
+#payment-overlay.active {
+  display: flex;
+}
+
+#payment-overlay iframe {
+  width: 90%;
+  max-width: 600px;
+  height: 90%;
+  border: none;
+  border-radius: 8px;
+}
+
+#payment-overlay .close-btn {
+  position: absolute;
+  top: 20px;
+  right: 20px;
+  background: #fff;
+  border: none;
+  border-radius: 50%;
+  width: 40px;
+  height: 40px;
+  font-size: 24px;
+  cursor: pointer;
+}

--- a/index.html
+++ b/index.html
@@ -131,6 +131,11 @@
 
   <div id="footer-placeholder"></div>
 
+  <div id="payment-overlay">
+    <button id="payment-close" class="close-btn">&times;</button>
+    <iframe id="payment-frame" src="" title="Chapa payment"></iframe>
+  </div>
+
   <script src="js/include.js"></script>
   <script src="js/main.js"></script>
     <script>

--- a/js/main.js
+++ b/js/main.js
@@ -407,29 +407,33 @@ document.addEventListener('partialsLoaded', () => {
   });
 });
 
-// Payment integration using Chapa test keys via API route
-async function buyProduct(product) {
-  const email = prompt('Enter your email:');
-  const firstName = prompt('First name:');
-  const lastName = prompt('Last name:');
-  if (!email || !firstName) return;
-  const amounts = { 'BaseLine': 50000, 'FocusLine': 40333, 'CyberLine': 202000 };
-  const amount = amounts[product] || 0;
-  try {
-    const response = await fetch('/api/checkout', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ amount: amount.toString(), email, first_name: firstName, last_name: lastName })
-    });
-    const data = await response.json();
-    if (data && data.data && data.data.checkout_url) {
-      window.location.href = data.data.checkout_url;
-    } else {
-      alert('Payment initialization failed');
-    }
-  } catch (err) {
-    alert('Error: ' + err.message);
+// Open Chapa checkout links in a popup overlay
+function buyProduct(product) {
+  const links = {
+    'BaseLine': 'http://checkout.chapa.co/checkout/web/payment/PL-S719TpsZ4WPy',
+    'FocusLine': 'http://checkout.chapa.co/checkout/web/payment/PL-52hYW0bOFVCu',
+    'CyberLine': 'http://checkout.chapa.co/checkout/web/payment/PL-bEbrRRqTcFng'
+  };
+  const url = links[product];
+  if (!url) return;
+  const overlay = document.getElementById('payment-overlay');
+  const frame = document.getElementById('payment-frame');
+  if (overlay && frame) {
+    frame.src = url;
+    overlay.classList.add('active');
   }
+}
+
+const paymentClose = document.getElementById('payment-close');
+if (paymentClose) {
+  paymentClose.addEventListener('click', () => {
+    const overlay = document.getElementById('payment-overlay');
+    const frame = document.getElementById('payment-frame');
+    if (overlay && frame) {
+      frame.src = '';
+      overlay.classList.remove('active');
+    }
+  });
 }
 
 // FAQ accordion toggling


### PR DESCRIPTION
## Summary
- open product purchase buttons in a modal with Chapa checkout links
- style and script overlay to dim the page and allow closing

## Testing
- ⚠️ `npm test` *(Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68ac012814048329bfddaa845d520b73